### PR TITLE
4.1 Shadows of the Shroud Update

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -473,3 +473,10 @@ Bugfixes:
 # 4.0.x Post-Wilderness-Beta Update
 Bugfixes:
 - district_*_max is now district_*_max_add.
+
+# 4.1.x Shadows of the Shroud Bugfix roundup
+Bugfixes: 
+- fixed botany agenda to match tooltip and rescaled for new pop numbers.
+- reenabled archaology event triggers.
+- Fixed ruination to use regular minor jobs instead of non-existent scrap miners.
+- Added astro-mining bays to the effects of the beaming array, so astro-mining drones can also benefit.

--- a/common/council_agendas/MT_council_agendas_traditions.txt
+++ b/common/council_agendas/MT_council_agendas_traditions.txt
@@ -1397,14 +1397,14 @@ agenda_MT_botany = {
 		has_tradition = tr_mt_botany_adopt
 	}
 	modifier = {
-		planet_farmers_food_produces_mult = -0.1
+		planet_farmers_food_produces_mult = -0.5
 	}
 	effect = {
 		custom_tooltip = council_agenda_agenda_MT_botany_effect_desc
         add_resource = {
-            physics_research = 100
-           	society_research = 100
-        	engineering_research = 100
+            physics_research = 1
+           	society_research = 1
+        	engineering_research = 1
             mult = value:MT_num_farmers
         }
 	}
@@ -1420,14 +1420,14 @@ agenda_MT_botany_angler = {
 		has_tradition = tr_mt_botany_adopt
 	}
 	modifier = {
-		planet_farmers_food_produces_mult = -0.1
+		planet_farmers_food_produces_mult = -0.5
 	}
 	effect = {
 		custom_tooltip = council_agenda_agenda_MT_botany_angler_effect_desc
         add_resource = {
-            physics_research = 200
-           	society_research = 200
-        	engineering_research = 200
+            physics_research = 2
+           	society_research = 2
+        	engineering_research = 2
             mult = value:MT_num_anglers
         }
 	}

--- a/common/on_actions/MT_on_actions.txt
+++ b/common/on_actions/MT_on_actions.txt
@@ -41,13 +41,13 @@ on_debris_scavenged_and_researched = {
 
 on_decade_pulse_country = {
 	events = {
-		#MT_events.4 # arcsite spawn
+		MT_events.4 # arcsite spawn
 	}
 }
 
 on_arch_site_finished = {
 	events = {
-		#MT_events.5 # Archaeology tradition
+		MT_events.5 # Archaeology tradition
 	}
 }
 

--- a/common/situations/MT_planet_modifier_situations.txt
+++ b/common/situations/MT_planet_modifier_situations.txt
@@ -416,7 +416,7 @@ MT_situation_ruination_spiteful_reclamations = {
 				}
 			}
 		}
-		job_scrap_miner_add = 1
+		job_miner_add = 100
 		mult = target.value:MT_half_planet_size
 	}
 	triggered_target_modifier = {
@@ -428,7 +428,7 @@ MT_situation_ruination_spiteful_reclamations = {
 				}
 			}
 		}
-		job_scrap_miner_drone_add = 1
+		job_mining_drone_add = 100
 		mult = target.trigger:planet_size
 	}
 	triggered_target_modifier = {
@@ -441,7 +441,7 @@ MT_situation_ruination_spiteful_reclamations = {
 				}
 			}
 		}
-		job_scrap_miner_drone_add = 1
+		job_mining_drone_add = 100
 		mult = target.value:MT_half_planet_size
 	}
 	on_start = {

--- a/common/starbase_buildings/MT_Hydra_starbase_buildings.txt
+++ b/common/starbase_buildings/MT_Hydra_starbase_buildings.txt
@@ -78,6 +78,11 @@ mt_starbase_energy_beaming = {
 				first = solar_panel_network
 				second = mt_starbase_energy_beaming
 			}
+			has_starbase_module = astromining_bay
+			starbase_buildable_is_in_queue_before = {
+				first = astromining_bay
+				second = mt_starbase_energy_beaming
+			}
 		}
 	}
 
@@ -93,6 +98,14 @@ mt_starbase_energy_beaming = {
 			}
 			energy = 2
 			mult = value:num_starbase_modules_of_type|TYPE|solar_panel_network|
+		}
+		produces = {
+			trigger = {
+				hidden_trigger = { exists = this }
+				has_starbase_module = astromining_bay
+			}
+			energy = 2
+			mult = value:num_starbase_modules_of_type|TYPE|astromining_bay|
 		}
 	}
 

--- a/descriptor.mod
+++ b/descriptor.mod
@@ -3,5 +3,5 @@ tags={
 	"Gameplay"
 }
 name="More Traditions"
-supported_version="v4.0.*"
+supported_version="v4.1.*"
 remote_file_id="3067902147"


### PR DESCRIPTION
No immediately apparent updates needed for 4.1. Patching errors.

MT_council_agendas_traditions.txt: fixed botany agenda to match tooltip and rescaled for new pop numbers.
MT_on_actions.txt: reenabled archaology event triggers.
MT_planet_modifier_situations.txt: Fixed ruination to use regular minor jobs instead of non-existent scrap miners.
MT_Hydra_starbase_buildings.txt: Added astro-mining bays to the effects of the beaming array, so astro-mining drones can also benefit.

Known issue: Media coverage tradition (tr_mt_archeology_respect_the_dead) not triggering it's associated event (MT_events.5) on arcsite completion, despite reenabling the on_action. Haven't figured out why yet.
